### PR TITLE
added simple cnn for binary classification of twitter sentiment (75% accuracy)

### DIFF
--- a/examples/wesley_twitter_cnn.ipynb
+++ b/examples/wesley_twitter_cnn.ipynb
@@ -1,0 +1,214 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CNN for binary classification of twitter sentiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 191,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Full dataset: 6090\n",
+      "dataset without NaN: 4225\n",
+      "Number of unique words: 3889\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "data = pd.read_csv(\"../../core/data/tweet_global_warming.csv\", encoding=\"latin\")\n",
+    "print(\"Full dataset: {}\".format(data.shape[0]))\n",
+    "data = data.dropna()\n",
+    "print(\"dataset without NaN: {}\".format(data.shape[0]))\n",
+    "X = data.iloc[:,0]\n",
+    "Y = data.iloc[:,1]\n",
+    "print(\"Number of unique words: {}\".format(len(np.unique(np.hstack(X)))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following cell I use keras' Tokenizer class to convert the sentiment column (Yes, Y, No, or no) to binary 0 (yes) or 1 (no)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 189,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/wesleybeckner/anaconda/envs/py36/lib/python3.6/site-packages/ipykernel_launcher.py:45: UserWarning: Update your `Conv1D` call to the Keras 2 API: `Conv1D(activation=\"relu\", filters=32, kernel_size=3, padding=\"same\")`\n",
+      "/Users/wesleybeckner/anaconda/envs/py36/lib/python3.6/site-packages/ipykernel_launcher.py:46: UserWarning: Update your `MaxPooling1D` call to the Keras 2 API: `MaxPooling1D(pool_size=2)`\n",
+      "/Users/wesleybeckner/anaconda/envs/py36/lib/python3.6/site-packages/keras/models.py:942: UserWarning: The `nb_epoch` argument in `fit` has been renamed `epochs`.\n",
+      "  warnings.warn('The `nb_epoch` argument in `fit` '\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "embedding_10 (Embedding)     (None, 500, 32)           160000    \n",
+      "_________________________________________________________________\n",
+      "conv1d_8 (Conv1D)            (None, 500, 32)           3104      \n",
+      "_________________________________________________________________\n",
+      "max_pooling1d_8 (MaxPooling1 (None, 250, 32)           0         \n",
+      "_________________________________________________________________\n",
+      "flatten_9 (Flatten)          (None, 8000)              0         \n",
+      "_________________________________________________________________\n",
+      "dense_17 (Dense)             (None, 250)               2000250   \n",
+      "_________________________________________________________________\n",
+      "dense_18 (Dense)             (None, 1)                 251       \n",
+      "=================================================================\n",
+      "Total params: 2,163,605\n",
+      "Trainable params: 2,163,605\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "None\n",
+      "Train on 3168 samples, validate on 1057 samples\n",
+      "Epoch 1/2\n",
+      "3168/3168 [==============================] - 5s 2ms/step - loss: 0.5816 - acc: 0.7323 - val_loss: 0.5610 - val_acc: 0.7389\n",
+      "Epoch 2/2\n",
+      "3168/3168 [==============================] - 4s 1ms/step - loss: 0.5148 - acc: 0.7371 - val_loss: 0.4667 - val_acc: 0.7569\n",
+      "Accuracy: 75.69%\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from keras.preprocessing.text import Tokenizer\n",
+    "from keras.models import Sequential\n",
+    "from keras.layers import Dense\n",
+    "from keras.layers import Flatten\n",
+    "from keras.layers.convolutional import Convolution1D\n",
+    "from keras.layers.convolutional import MaxPooling1D\n",
+    "from keras.layers.embeddings import Embedding\n",
+    "from keras.preprocessing import sequence\n",
+    "\n",
+    "# fix random seed for reproducibility\n",
+    "seed = 7\n",
+    "numpy.random.seed(seed)\n",
+    "\n",
+    "# load the dataset but only keep the top n words, zero the rest\n",
+    "top_words = 5000\n",
+    "def shift_one(obj):\n",
+    "    return obj - 1\n",
+    "X = data.iloc[:,0]\n",
+    "Y = data.iloc[:,1]\n",
+    "Y = list(map(str, Y))\n",
+    "token = Tokenizer(num_words=top_words, filters='!\"#$%&()*+,-./:;<=>?@[\\]^_`{|}~',\n",
+    "          lower=True, split=' ', char_level=False, oov_token=None)\n",
+    "token.fit_on_texts(texts=X)\n",
+    "X = token.texts_to_sequences(texts=X)\n",
+    "token = Tokenizer(num_words=None, filters='!\"#$%&()*+,-./:;<=>?@[\\]^_`{|}~eso',\n",
+    "          lower=True, split=' ', char_level=False, oov_token=None)\n",
+    "token.fit_on_texts(texts=Y)\n",
+    "Y = token.texts_to_sequences(texts=Y)\n",
+    "Y = np.array(Y)\n",
+    "Y = Y.reshape(Y.shape[0],)\n",
+    "Y = list(map(shift_one, Y))\n",
+    "Y = np.array(Y)\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X,Y)\n",
+    "\n",
+    "# pad dataset to a maximum review length in words\n",
+    "max_words = 500\n",
+    "X_train = sequence.pad_sequences(X_train, maxlen=max_words)\n",
+    "X_test = sequence.pad_sequences(X_test, maxlen=max_words)\n",
+    "\n",
+    "# create the model\n",
+    "model = Sequential()\n",
+    "model.add(Embedding(top_words, 32, input_length=max_words)) \n",
+    "model.add(Convolution1D(nb_filter=32, filter_length=3, border_mode='same', activation='relu'))\n",
+    "model.add(MaxPooling1D(pool_length=2))\n",
+    "model.add(Flatten())\n",
+    "model.add(Dense(250, activation='relu'))\n",
+    "model.add(Dense(1, activation='sigmoid')) \n",
+    "model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy']) \n",
+    "print(model.summary())\n",
+    "\n",
+    "# Fit the model\n",
+    "model.fit(X_train, y_train, validation_data=(X_test, y_test), nb_epoch=2, batch_size=128,\n",
+    "    verbose=1)\n",
+    "\n",
+    "# Final evaluation of the model\n",
+    "scores = model.evaluate(X_test, y_test, verbose=0)\n",
+    "print(\"Accuracy: %.2f%%\" % (scores[1]*100))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 192,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "average tweet length: \n",
+      "111.800\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD8CAYAAAB5Pm/hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAF99JREFUeJzt3X2QXfV93/H3B8mWDX6SRmtF6KFSPDJPmoDxliFxqwEL\nGzV4LDrTYbQUW6o0VlMT4mTcwRL6A/cPddQmtWPTwowKBHlCVqOhuGjiQC0reBhmCniFMSAJIjXi\nQYqEFkNCmkwFkj/94x7BZbVXu3vv3b13f/t5zezcc37n4X4vOvfDub/7u+fINhERUa5zOl1ARESM\nrwR9REThEvQREYVL0EdEFC5BHxFRuAR9REThEvQREYVL0EdEFC5BHxFRuOmdLgBg9uzZXrRoUafL\niILt2bPndds9E/28ObZjPI32uO6KoF+0aBEDAwOdLiMKJunlTjxvju0YT6M9rtN1E8Vbu3YtwKWS\nnh+6TNI3JVnS7Lq2jZIOSnpR0rV17Z+V9Fy17PuSNDGvIKI1Cfoo3po1awAODG2XtAD4IvBKXdvF\nwCrgEmAFcKekadXiu4CvAUuqvxXjWXdEuyToo3jLli0DODnMou8CtwL1l3BdCWy3fcL2IeAgcIWk\nucDHbD/h2iVffwBcP76VR7RHgj6mJEkrgSO2fzFk0Tzg1br5w1XbvGp6aHtE1+uKL2MjJpKkc4Hb\nqHXbjMf+1wPrARYuXDgeTxExJjmjj6noU8Bi4BeSXgLmA09L+jXgCLCgbt35VduRanpo+xlsb7Xd\na7u3p2fCR3RGnGHEoJd0r6TjQ0csSLpF0guS9kr6z3Xtw45YiOgWtp+z/Unbi2wvotYNc7ntY8BO\nYJWkGZIWU/vS9SnbR4G3JF1Zjbb5KvBQp15DxFiMpuvmPuC/UvvyCQBJV1P70upS2yckfbJqrx+x\ncD7wE0mftn2q3YVHjFZfXx/AhYAkHQZut33PcOva3itpB7CP2he4N9cdv1+n9n74MPBw9RfR9UY8\no7f9GPDGkOZ/B2yxfaJa53jVPuyIhTbWO+VIGtNfnKm/vx/gWdsfsD1/aMhXZ/av181vtv0p2xfY\nfriufcD20mrZ7zo3XI5JotkvYz8N/HNJm4H/B/x72z+jNgrhibr1MjKhRcNliaRh2yNiYiza8KMx\nb/PSluvGoZLRaTbopwOzgCuBfwrskPTrY9lBRiZEREyMZkfdHAYedM1TwK+A2TQesXCGjEyIiJgY\nzQb9/wSuBpD0aeCDwOs0GLHQjkIjIqI5I3bdSOoHrgJmnx6xANwL3FsNuXwbWF19MXW2EQsREdEB\nIwa97b4Gi25qsP5mYHMrRUVERPvkl7EREYVL0EdEFC5BHxFRuAR9REThEvQREYVL0EdEFC5BHxFR\nuAR9REThEvQREYVL0EdEFC5BHxFRuAR9REThEvQREYVL0EdEFC5BHxFRuAR9FG/t2rUAl1Y3ygFA\n0h9KekHSs5J+KOkTdcs2Sjoo6UVJ19a1f1bSc9Wy70vSxL6SiOYk6KN4a9asATgwpHkXsNT2bwB/\nBWwEkHQxsAq4BFgB3ClpWrXNXcDXqN0ic0m1PKLrJeijeMuWLYParS3fZfvHtk+3PUHtRvYAK4Ht\ntk/YPgQcBK6QNBf4mO0nqttm/gC4fkJeQESLEvQRsBZ4uJqeB7xat+xw1Tavmh7aHtH1Rgx6SfdK\nOl7fv1m37JuSLGl2Xduw/ZsR3UjSJmpn+/e3cZ/rJQ1IGhgcHGzXbiOaNpoz+vsYpi9S0gLgi8Ar\ndW1n69+M6CqS1gBfAv511R0DcARYULfa/KrtCO9179S3n8H2Vtu9tnt7enraXnfEWI0Y9LYfA94Y\nZtF3gVsB17UN27/ZjkIj2knSCmrH75dt/2Pdop3AKkkzJC2m9qXrU7aPAm9JurIabfNV4KEJLzyi\nCdOb2UjSSuCI7V8MGWE2j9oXW6elHzM6rq+vD+BCQJIOA7dTG2UzA9hVHcNP2P4d23sl7QD2UevS\nudn2qWpXX6f2CffD1Pr0HyZiEhhz0Es6F7iNWrdN0yStB9YDLFy4sJVdRZxVf38/27dvf9Z2b13z\nPY3Wt70Z2DxM+wCwdBxKjBhXzYy6+RSwGPiFpJeo9VU+LenXaNy/eYb0Y0ZETIwxB73t52x/0vYi\n24uodc9cbvsYDfo321pxRESMyWiGV/YD/xu4QNJhSesarWt7L3C6f/MR3t+/GRERHTBiH73tvhGW\nLxoyP2z/ZpzdrFmzePPNN0e9/lguszJz5kzeeGO4gVMRMRU0Neom2u/NN9/kvaHc7ZVrb0VMbbkE\nQkRE4RL0ERGFS9BHRBQuQR8RUbgEfURE4RL0ERGFS9BHRBQuQR8RUbgEfURE4RL0ERGFS9BHRBQu\nQR8RUbgEfURE4RL0ERGFS9BHRBQuQR8RUbgEfURE4RL0Uby1a9cCXCrp+dNtkmZJ2iXpQPU4s27Z\nRkkHJb0o6dq69s9Keq5a9n3l1l0xSYzm5uD3Sjo+5E3yh5JekPSspB9K+kTdsmHfJBGdsmbNGoAD\nQ5o3ALttLwF2V/NIuhhYBVwCrADulDSt2uYu4GvAkupvxXjXHtEOozmjv48zD+hdwFLbvwH8FbAR\nRnyTRHTEsmXLAE4OaV4JbKumtwHX17Vvt33C9iHgIHCFpLnAx2w/4drNfX9Qt01EVxsx6G0/Brwx\npO3Htk+/cZ4A5lfTw75J2lhvRLvMsX20mj4GzKmm5wGv1q13uGqbV00PbT+DpPWSBiQNDA4Otrfq\niCa0o49+LfBwNd3oTRLRtaozdLdxf1tt99ru7enpadduI5o2vZWNJW2i9pH4/ia2XQ+sB1i4cGEr\nZRTBt38Mvv3x8dt3DPWapLm2j1bdMser9iPAgrr15ldtR3jvk2t9e0TXazroJa0BvgQsr86IoPGb\n5Ay2twJbAXp7e9t2NjVZ6T+8xXv/Gdu8bwl/e1x2PZntBFYDW6rHh+ra/0zSd4DzqX3p+pTtU5Le\nknQl8CTwVeCOiS87Yuya6rqRtAK4Ffiy7X+sW7QTWCVphqTFVG+S1suMaF5fXx/AhcAFkg5LWkct\n4L8g6QBwTTWP7b3ADmAf8Ahws+1T1a6+DtxN7bun/8N7XZYRXW3EM3pJ/cBVwGxJh4HbqY2ymQHs\nqoYSP2H7d2zvlXT6TXKS979JIjqiv7+f7du3P2u7d8ii5cOtb3szsHmY9gFg6TiUGDGuRgx6233D\nNN9zlvWHfZNERERn5JexERGFS9BHRBQuQR8RUbgEfURE4RL0ERGFS9BHRBQuQR8RUbgEfURE4RL0\nERGFS9BHRBQuQR8RUbgEfURE4RL0ERGFS9BHRBQuQR8RUbgEfURE4RL0ERGFS9BHRBQuQR8RUbgE\nfURE4UYMekn3Sjou6fm6tlmSdkk6UD3OrFu2UdJBSS9Kuna8Co9olaQ/kLRX0vOS+iV9KMd2lGg0\nZ/T3ASuGtG0AdtteAuyu5pF0MbAKuKTa5k5J09pWbUSbSJoH/B7Qa3spMI3asZtjO4ozYtDbfgx4\nY0jzSmBbNb0NuL6ufbvtE7YPAQeBK9pUa0S7TQc+LGk6cC7wN+TYjgI120c/x/bRavoYMKeange8\nWrfe4artDJLWSxqQNDA4ONhkGRHNsX0E+CPgFeAo8He2f0wbju2IbtPyl7G2DbiJ7bba7rXd29PT\n02oZEWNS9b2vBBYD5wPnSbqpfp1mj+2cxES3aTboX5M0F6B6PF61HwEW1K03v2qL6DbXAIdsD9p+\nB3gQ+C3acGznJCa6TbNBvxNYXU2vBh6qa18laYakxcAS4KnWSowYF68AV0o6V5KA5cB+cmxHgaaP\ntIKkfuAqYLakw8DtwBZgh6R1wMvADQC290raAewDTgI32z41TrVHNM32k5IeAJ6mdqz+HNgKfIQc\n21GYEYPedl+DRcsbrL8Z2NxKURETwfbt1E5c6p0gx/aUsWjDjzpdwoTIL2MjIgqXoI+IKFyCPiKi\ncAn6iIjCJegjIgqXoI+IKFyCPiKicCOOo4+JU/uBZvvNnDlz5JUiolgJ+i5Ru37W6Ega0/oRMbWl\n6yYionAJ+oiIwiXoIyIKl6CPiChcgj4ionAJ+oiIwiXoIyIKl6CPiChcgj4ionAJ+oiIwrUU9JL+\nQNJeSc9L6pf0IUmzJO2SdKB6zIVWIiI6qOmglzQP+D2g1/ZSYBqwCtgA7La9BNhdzUdERIe02nUz\nHfiwpOnAucDfACuBbdXybcD1LT5HxLiR9AlJD0h6QdJ+Sb95tk+lkjZKOijpRUnXdrL2iNFqOuht\nHwH+CHgFOAr8ne0fA3NsH61WOwbMabnKiPHzPeAR2xcClwL7afCpVNLF1D61XgKsAO6UNK0jVUeM\nQStdNzOpnb0vBs4HzpN0U/06rl1Ld9jr6UpaL2lA0sDg4GCzZUQ0TdLHgWXAPQC237b9tzT+VLoS\n2G77hO1DwEHgiomtOmLsWum6uQY4ZHvQ9jvAg8BvAa9JmgtQPR4fbmPbW2332u7t6elpoYyIpi0G\nBoE/kfRzSXdLOo/Gn0rnAa/WbX+4aovoaq0E/SvAlZLOVe3WSMupfezdCayu1lkNPNRaiRHjZjpw\nOXCX7c8A/8CQwQNn+1TaSD6tRrdppY/+SeAB4GnguWpfW4EtwBckHaB21r+lDXVGjIfDwOHqWIba\n8Xw5jT+VHgEW1G0/v2p7n3xajW7T0qgb27fbvtD2Uttfqfouf2l7ue0ltq+x/Ua7io1oJ9vHgFcl\nXVA1LQf20fhT6U5glaQZkhYDS4CnJrDkiKbknrEx1d0C3C/pg8BfA/+G2gnQDknrgJeBGwBs75W0\ng9r/DE4CN9s+1ZmyI0YvQR9Tmu1ngN5hFi1vsP5mYPO4FhXRZrnWTURE4RL0ERGFS9dNREx6izb8\nqNMldLWc0UdEFC5BHxFRuAR9REThEvQREYVL0EdEFC5BHxFRuAR9REThEvQREYVL0EdEFC5BHxFR\nuAR9REThcq2biGi7Zq8989KW69pcSUDO6CMiipegj4goXEtBL+kTkh6Q9IKk/ZJ+U9IsSbskHage\nZ7ar2IiIGLtW++i/Bzxi+19V99w8F7gN2G17i6QNwAbgWy0+T0RMAbmu/Pho+oxe0seBZcA9ALbf\ntv23wEpgW7XaNuD6VouMiIjmtdJ1sxgYBP5E0s8l3S3pPGCO7aPVOseAOa0WGRERzWsl6KcDlwN3\n2f4M8A/UumneZduAh9tY0npJA5IGBgcHWygjIiLOppWgPwwctv1kNf8AteB/TdJcgOrx+HAb295q\nu9d2b09PTwtlRDRP0rTqE+mfV/MNBxNI2ijpoKQXJV3buaojxqbpoLd9DHhV0gVV03JgH7ATWF21\nrQYeaqnCiPH1DWB/3fwGaoMJlgC7q3kkXQysAi4BVgB3Spo2wbVGNKXVcfS3APdLeha4DPiPwBbg\nC5IOANdU8xFdR9J84Drg7rrmRoMJVgLbbZ+wfQg4CFwxUbVGtKKl4ZW2nwF6h1m0vJX9RkyQPwZu\nBT5a19ZoMME84Im69Q5XbWeQtB5YD7Bw4cJ21hvRlPwyNqYkSV8Cjtve02idsw0mOJt8/xTdJhc1\ni6nqc8CXJf028CHgY5L+lGowge2jQwYTHAEW1G0/v2qL6Ho5o48pyfZG2/NtL6L2Jetf2r6JxoMJ\ndgKrJM2QtBhYAjw1wWVHNCVn9BHvtwXYIWkd8DJwA4DtvZJ2UBtZdhK42fapzpUZMXoJ+pjybP8U\n+Gk1/UsaDCawvRnYPGGFRbRJum4iIgqXoI+IKFyCPiKicAn6iIjCJegjIgqXoI+IKFyGV0ZEQ7m1\nXxlyRh8RUbgEfURE4RL0ERGFS9BHRBQuQR8RUbgEfURE4RL0ERGFaznoJU2T9HNJf17Nz5K0S9KB\n6nFm62VGRESz2nFG/w1gf938BmC37SXA7mo+IiI6pKWglzQfuA64u655JbCtmt4GXN/Kc0RERGta\nPaP/Y+BW4Fd1bXNsH62mjwFzWnyOiIhoQdNBL+lLwHHbexqtY9uAG2y/XtKApIHBwcFmy4iIiBG0\nckb/OeDLkl4CtgOfl/SnwGuS5gJUj8eH29j2Vtu9tnt7enpaKCMiIs6m6aC3vdH2fNuLgFXAX9q+\nCdgJrK5WWw081HKVERHRtPEYR78F+IKkA8A11XxE15G0QNKjkvZJ2ivpG1V7wyHCkjZKOijpRUnX\ndq76iNFry/Xobf8U+Gk1/UtgeTv2GzHOTgLftP20pI8CeyTtAtZQGyK8RdIGakOEvyXpYmqfXi8B\nzgd+IunTtk91qP6IUckvY2PKsn3U9tPV9N9T+z3IPBoPEV4JbLd9wvYh4CBwxcRWHTF2CfoIQNIi\n4DPAkzQeIjwPeLVus8NVW0RXS9DHlCfpI8D/AH7f9lv1y842RPgs+8vQ4egqCfqY0iR9gFrI32/7\nwaq50RDhI8CCus3nV23vk6HD0W0S9DFlSRJwD7Df9nfqFjUaIrwTWCVphqTFwBLgqYmqN6JZbRl1\nEzFJfQ74CvCcpGeqttuoDQneIWkd8DJwA4DtvZJ2APuojdi5OSNuYjJI0MeUZftxQA0WDztE2PZm\nYPO4FTWOFm34UadLiA5J101EROES9BERhUvQR0QULkEfEVG4BH1EROES9BERhUvQR0QULkEfEVG4\nBH1EROES9BERhUvQR0QULkEfEVG4BP0k0t/fz9KlSwFYunQp/f39Ha4oIiaDpoNe0gJJj0raJ2mv\npG9U7bMk7ZJ0oHqc2b5yp67+/n42bdrEHXfcAcAdd9zBpk2bEvYRMaJWLlN8Evim7aclfRTYI2kX\nsAbYbXuLpA3ABuBbrZc6NdXujfGez3/+8+97vPHGG7nxxhvfXV67811ExHuaPqO3fdT209X03wP7\nqd0oeSWwrVptG3B9q0VOZbaxzTnnnMPbb7/97rxt3n77bc4555z3tUVEDNWWG49IWgR8BngSmGP7\naLXoGDCnwTbrgfUACxcubEcZRbvooot4/PHHufrqq99te/zxx7nooos6WFV0Qm4gEmPV8pexkj5C\n7ebKv2/7rfplrp1iDnuamRsoj82mTZtYt24djz76KO+88w6PPvoo69atY9OmTZ0uLSK6XEtn9JI+\nQC3k77f9YNX8mqS5to9Kmgscb7XIgL6+PgBuueUW9u/fz0UXXcTmzZvfbY+I7tbsJ7GXtlzX8nM3\nHfSqfUt4D7Df9nfqFu0EVlO7wfJq4KGWKox39fX1JdgjYsxaOaP/HPAV4DlJz1Rtt1EL+B2S1gEv\nAze0VmJERLSi6aC3/TigBouXN7vfiG4maQXwPWAacLftLR0uKWJE+WVsxChJmgb8N+BfABcDfZIu\n7mxVESNry/DKiCniCuCg7b8GkLSd2u9G9jWzswyTjImSM/qI0ZsHvFo3f7hqi+hqXXFGv2fPntcl\nvdzpOiaR2cDrnS5ikvknE/VE9T8GBP6vpBcn6rlHoYRjZ0q9Bv2nsy4e1XHdFUFvO7+YGgNJA7Z7\nO13HFHQEWFA3P79qex/bW4GtE1XUWJRw7OQ1jF26biJG72fAEkmLJX0QWEXtdyMRXa0rzugjJgPb\nJyX9LvC/qA2vvNf23g6XFTGiBP3k1JXdAlOB7b8A/qLTdbSghGMnr2GMlEvbRkSULX30ERGFS9BP\nIpLulXRc0vOdriW6n6SXJD0n6RlJA1VbV9/qc7hj/Gw1S9oo6aCkFyVd25mqz9TgdXxb0pHq3+MZ\nSb9dt2xcX0eCfnK5D1jR6SJiUrna9mV1Q/k2ULvV5xJgdzXfTe7jzGN82Jqry0+sAi6ptrmzukxF\nN7iP4d+r363+PS6rvu+ZkNeRoJ9EbD8GvNHpOmJS6+pbfTY4xhvVvBLYbvuE7UPAQWqXqei4Mb5X\nx/11JOgjymXgJ5L2VL/WhVHe6rPLNKp5Ml6S4hZJz1ZdO6e7oMb9dSToI8r1z2xfRu1qmzdLWla/\n8Gy3+uxWk7HmOncBvw5cBhwF/stEPXGCPqJQto9Uj8eBH1LrDnitusUnk+hWn41qHtUlKbqF7dds\nn7L9K+C/8173zLi/jgR9RIEknSfpo6engS8Cz/PerT5h8tzqs1HNO4FVkmZIWgwsAZ7qQH2jcvp/\nVpV/Se3fAybgdeSXsZOIpH7gKmC2pMPA7bbv6WxV0aXmAD+s3dqZ6cCf2X5E0s/o4lt9DneM0+D2\npLb3StpB7X4AJ4GbbZ/qSOFDNHgdV0m6jFrX00vAv4WJeR35ZWxEROHSdRMRUbgEfURE4RL0ERGF\nS9BHRBQuQR8RUbgEfURE4RL0ERGFS9BHRBTu/wP+Ij47Hbtp+QAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11a73f8d0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from matplotlib import pyplot\n",
+    "# Summarize review length\n",
+    "print(\"average tweet length: \")\n",
+    "result = map(len, X)\n",
+    "print(\"{:.3f}\".format(np.mean(list(map(len, X)))))\n",
+    "pyplot.subplot(121)\n",
+    "pyplot.boxplot(list(map(len, X)))\n",
+    "pyplot.subplot(122)\n",
+    "pyplot.hist(list(map(len, X)))\n",
+    "pyplot.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
check it out! created CNN for binary classification of twitter sentiment (I don't consider NaN assignments) trained for 2 epochs to get 75% accuracy on test dataset:
```
model = Sequential()
model.add(Embedding(top_words, 32, input_length=max_words)) model.add(Convolution1D(nb_filter=32, filter_length=3, border_mode='same',
activation='relu'))
model.add(MaxPooling1D(pool_length=2))
model.add(Flatten())
model.add(Dense(250, activation='relu'))
model.add(Dense(1, activation='sigmoid')) model.compile(loss='binary_crossentropy', optimizer='adam', metrics=['accuracy'])
```
input twitter data was screened for top 5000 words (not a significant cutoff as there were only just over 5000) and each resultant vector was padded or trimmed to 500 integers